### PR TITLE
Fix append_symbol_data extension

### DIFF
--- a/ami2py/ami_database.py
+++ b/ami2py/ami_database.py
@@ -180,4 +180,5 @@ class AmiDataBase(AmiDbFolderLayout):
             if symbol not in self._symbol_cache:
                 self._symbol_cache[symbol] = SymbolData(Entries=data)
             else:
-                self._symbol_cache[symbol].append(data)
+                for entry in data:
+                    self._symbol_cache[symbol].append(entry)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -114,6 +114,39 @@ def test_AmiDataBase_should_append_symbol_data():
     assert len(aapl["Day"]) == 2
 
 
+def test_append_symbol_data_twice_increases_entries():
+    test_database_folder = os.path.join(test_data_folder, "./TestData")
+    db = AmiDataBase(test_database_folder)
+    first = {
+        "AAPL": {
+            "Close": [200.0, 201.0],
+            "High": [202, 203],
+            "Low": [199, 199.1],
+            "Open": [200, 200],
+            "Volume": [200001212.0, 213001311],
+            "Month": [12, 12],
+            "Year": [2020, 2020],
+            "Day": [17, 18],
+        }
+    }
+    second = {
+        "AAPL": {
+            "Close": [202.0, 203.0],
+            "High": [204, 205],
+            "Low": [200, 200.1],
+            "Open": [202, 203],
+            "Volume": [220001212.0, 230001311],
+            "Month": [12, 12],
+            "Year": [2020, 2020],
+            "Day": [19, 20],
+        }
+    }
+    db.append_symbol_data(first)
+    db.append_symbol_data(second)
+    aapl = db.get_dict_for_symbol("AAPL")
+    assert len(aapl["Day"]) == 4
+
+
 def test_AmiDataBase_should_create_new_db():
     # Setup folders
     test_database_folder = os.path.join(test_data_folder, "./NewData")


### PR DESCRIPTION
## Summary
- fix list append bug in `append_symbol_data`
- add regression test for appending data twice

## Testing
- `python -m pytest tests/test_database.py::test_append_symbol_data_twice_increases_entries -q` *(fails: No module named pytest)*