### PR TITLE
Add append_symbol_entry alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ AmiDataBase constructor. This is a more or less experimental feature.
     >>> from ami2py import AmiDataBase, SymbolEntry
     >>> db = AmiDataBase(db_folder)
     >>> db.add_symbol("AAPL")    
-    >>> db.append_data_to_symbol(
+    >>> db.append_symbol_entry(
             "AAPL",
             SymbolEntry(
                 Close=200.0,

--- a/ami2py/ami_database.py
+++ b/ami2py/ami_database.py
@@ -145,6 +145,15 @@ class AmiDataBase(AmiDbFolderLayout):
         self.read_fast_data_for_symbol(symbol_name)
         return self._fast_symbol_cache[symbol_name]
 
+    def append_symbol_entry(self, symbol, data: SymbolEntry):
+        """Append a :class:`SymbolEntry` to ``symbol``.
+
+        This method supersedes the old :func:`append_symbole_entry` with the
+        correct spelling and simply forwards to it for backwards
+        compatibility.
+        """
+        return self.append_symbole_entry(symbol, data)
+
     def append_symbole_entry(self, symbol, data: SymbolEntry):
         """
         :param symbol: name of the symbol to which data should be appended

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -53,7 +53,7 @@ def test_AmiDataBase_should_append_symbol_entry():
     db = AmiDataBase(test_database_folder)
     # Only data for the symbol SPCE is contained in the TestData folder !!
     try:
-        db.append_symbole_entry(
+        db.append_symbol_entry(
             "AAPL",
             SymbolEntry(
                 Close=200.0,
@@ -66,7 +66,7 @@ def test_AmiDataBase_should_append_symbol_entry():
                 Day=17,
             ),
         )
-        db.append_symbole_entry(
+        db.append_symbol_entry(
             "AAPL",
             SymbolEntry(
                 Close=200,
@@ -156,7 +156,7 @@ def test_AmiDataBase_should_create_new_db():
     db = AmiDataBase(test_database_folder)
     db.add_symbol("AAPL")
     try:
-        db.append_symbole_entry(
+        db.append_symbol_entry(
             "AAPL",
             SymbolEntry(
                 Close=200.0,


### PR DESCRIPTION
## Summary
- add `append_symbol_entry` to call existing `append_symbole_entry`
- update README example to use new name
- update tests to use new method

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*