### PR TITLE
Add force_refresh option for symbol data

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ Getting values for a symbol in a pandas compatible dicitonary format.
         "Day": [17,........],
     }
 
+`get_dict_for_symbol` caches the returned data for subsequent calls. If the
+underlying database has changed, pass `force_refresh=True` to reload the latest
+values from disk:
+
+```python
+>>> db.get_dict_for_symbol("SPCE", force_refresh=True)
+```
+
 Using a list container facade for fast reading of symbol data. 
 The previous mentioned methods to read symbol data from the database use construct to 
 convert the binary array into a hierarchical object structure. 

--- a/ami2py/ami_database.py
+++ b/ami2py/ami_database.py
@@ -124,25 +124,19 @@ class AmiDataBase(AmiDbFolderLayout):
     def read_raw_data_for_symbol(self, symbol_name):
         return self.reader.get_symbol_data_raw(symbol_name)
 
-    def get_dict_for_symbol(self, symbol_name):
-        if symbol_name in self._symbol_cache:
-            return self._symbol_cache[symbol_name].to_dict()
-
-        self.read_data_for_symbol(symbol_name)
+    def get_dict_for_symbol(self, symbol_name, force_refresh=False):
+        if force_refresh or symbol_name not in self._symbol_cache:
+            self.read_data_for_symbol(symbol_name)
         return self._symbol_cache[symbol_name].to_dict()
 
-    def get_symbol_data(self, symbol_name):
-        if symbol_name in self._symbol_cache:
-            return self._symbol_cache[symbol_name]
-
-        self.read_data_for_symbol(symbol_name)
+    def get_symbol_data(self, symbol_name, force_refresh=False):
+        if force_refresh or symbol_name not in self._symbol_cache:
+            self.read_data_for_symbol(symbol_name)
         return self._symbol_cache[symbol_name]
 
-    def get_fast_symbol_data(self, symbol_name):
-        if symbol_name in self._fast_symbol_cache:
-            return self._fast_symbol_cache[symbol_name]
-
-        self.read_fast_data_for_symbol(symbol_name)
+    def get_fast_symbol_data(self, symbol_name, force_refresh=False):
+        if force_refresh or symbol_name not in self._fast_symbol_cache:
+            self.read_fast_data_for_symbol(symbol_name)
         return self._fast_symbol_cache[symbol_name]
 
     def append_symbole_entry(self, symbol, data: SymbolEntry):


### PR DESCRIPTION
## Summary
- add `force_refresh` parameter to refresh cached symbol data
- document cache refresh in README

## Testing
- `pytest` *(fails: command not found)*