### PR TITLE
Implement iteration and clean unused header

### DIFF
--- a/ami2py/ami_symbol_facade.py
+++ b/ami2py/ami_symbol_facade.py
@@ -246,9 +246,6 @@ class AmiSymbolDataFacade:
         # self.default_header[-2] = (self.length & 0xff0000) >> 16
         # self.default_header[-1] = (self.length & 0xff000000) >> 24
 
-    def _create_blank_header(self):
-        pass
-
     def __len__(self):
         return self.length
 
@@ -294,7 +291,8 @@ class AmiSymbolDataFacade:
         }
 
     def __iter__(self):
-        pass
+        for i in range(self.length):
+            yield self._get_item_by_index(i)
 
     def __iadd__(self, other):
         # assert all (k in entry_map for k in other)

--- a/tests/test_basic_read.py
+++ b/tests/test_basic_read.py
@@ -70,6 +70,17 @@ def test_add_to_amisymbolfacade():
     assert facade[-1]["AUX2"] == facade[-2]["AUX2"]
 
 
+def test_iter_amisymbolfacade():
+    test_data_folder = os.path.dirname(__file__)
+    test_data_file = os.path.join(test_data_folder, "./TestData/s/SPCE")
+    with open(test_data_file, "rb") as f:
+        binfile = f.read()
+    facade = AmiSymbolDataFacade(binfile)
+    first_iter = next(iter(facade))
+    assert first_iter == facade[0]
+    assert sum(1 for _ in facade) == facade.length
+
+
 def test_amistruct_master(master_data):
     parsed = Master.parse(master_data)
     assert parsed["NumSymbols"] == 5618


### PR DESCRIPTION
## Summary
- remove unused `_create_blank_header`
- implement `__iter__` for `AmiSymbolDataFacade`
- test iteration over `AmiSymbolDataFacade`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*