### PR TITLE
Fix append functions preserve symbol data

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -25,6 +25,7 @@ def test_AmiDataBase_should_get_dict_for_symbol():
     assert aapl["Month"][0] == 9
     assert aapl["Year"][0] == 2017
 
+
 def test_AmiDataBase_should_get_fastdata_for_symbol():
     test_database_folder = os.path.join(test_data_folder, "./TestData")
     db = AmiDataBase(test_database_folder)
@@ -35,6 +36,7 @@ def test_AmiDataBase_should_get_fastdata_for_symbol():
     assert symbol[0]["Year"] == 2017
     assert len(symbol[0:10]) == 10
 
+
 def test_AmiDataBase_should_get_fastdata_for_symbol_negative_indexed():
     test_database_folder = os.path.join(test_data_folder, "./TestData")
     db = AmiDataBase(test_database_folder)
@@ -43,10 +45,11 @@ def test_AmiDataBase_should_get_fastdata_for_symbol_negative_indexed():
     assert symbol[-1]["Day"] == 19
     assert symbol[-1]["Month"] == 2
     assert symbol[-1]["Year"] == 2020
-    assert round(symbol[-1]["Open"],2) == 34.3
+    assert round(symbol[-1]["Open"], 2) == 34.3
     assert round(symbol[-1]["Close"], 2) == 37.35
     assert round(symbol[-1]["High"], 2) == 37.5
     assert round(symbol[-1]["Low"], 2) == 32
+
 
 def test_AmiDataBase_should_append_symbol_entry():
     test_database_folder = os.path.join(test_data_folder, "./TestData")
@@ -176,6 +179,68 @@ def test_append_symbol_data_twice_increases_entries():
     db.append_symbol_data(second)
     aapl = db.get_dict_for_symbol("AAPL")
     assert len(aapl["Day"]) == 4
+
+
+def test_append_symbol_entry_without_preload(tmp_path):
+    src = os.path.join(test_data_folder, "TestData")
+    db_path = tmp_path / "AppendNoLoad"
+    shutil.copytree(src, db_path)
+
+    original_db = AmiDataBase(db_path)
+    original_length = len(original_db.get_dict_for_symbol("SPCE")["Day"])
+
+    db = AmiDataBase(db_path)
+    db.append_symbol_entry(
+        "SPCE",
+        SymbolEntry(
+            Close=1.0,
+            High=1.0,
+            Low=1.0,
+            Open=1.0,
+            Volume=1.0,
+            Month=1,
+            Year=2024,
+            Day=1,
+        ),
+    )
+    db.write_database()
+
+    check_db = AmiDataBase(db_path)
+    updated = check_db.get_dict_for_symbol("SPCE")
+    assert len(updated["Day"]) == original_length + 1
+    assert updated["Day"][-1] == 1
+    assert updated["Year"][-1] == 2024
+
+
+def test_append_symbol_data_without_preload(tmp_path):
+    src = os.path.join(test_data_folder, "TestData")
+    db_path = tmp_path / "AppendDictNoLoad"
+    shutil.copytree(src, db_path)
+
+    original_db = AmiDataBase(db_path)
+    original_length = len(original_db.get_dict_for_symbol("SPCE")["Day"])
+
+    db = AmiDataBase(db_path)
+    entries = {
+        "SPCE": {
+            "Close": [2.0],
+            "High": [2.0],
+            "Low": [2.0],
+            "Open": [2.0],
+            "Volume": [2.0],
+            "Month": [2],
+            "Year": [2024],
+            "Day": [2],
+        }
+    }
+    db.append_symbol_data(entries)
+    db.write_database()
+
+    check_db = AmiDataBase(db_path)
+    updated = check_db.get_dict_for_symbol("SPCE")
+    assert len(updated["Day"]) == original_length + 1
+    assert updated["Day"][-1] == 2
+    assert updated["Month"][-1] == 2
 
 
 def test_AmiDataBase_should_create_new_db():


### PR DESCRIPTION
## Summary
- preserve existing symbol data when appending entries
- handle pre-existing data in `append_symbol_data`
- regression tests for appending without preloading data

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*