### PR TITLE
Add optional Rust backend for bit parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,10 @@ Key Points
 4. **Database folder layout** – `AmiDbFolderLayout` specifies in which subfolder
    symbols are stored (e.g. `a/AAPL`).
 
+
+### Optional Rust Backend
+
+The bit parsing logic can optionally be executed using a Rust implementation. Set
+`AMI2PY_USE_RUST=1` in the environment to activate the Rust backend (requires the
+`rust_bitparser` extension to be built). If the extension is not available, the
+library falls back to the pure Python implementation.

--- a/ami2py/ami_symbol_facade.py
+++ b/ami2py/ami_symbol_facade.py
@@ -31,6 +31,7 @@ from .consts import (
 )
 from .ami_bitstructs import EntryChunk
 from .ami_construct import SymbolHeader
+from .bitparser import read_date, reverse_bits
 import struct
 
 entry_map = [
@@ -133,27 +134,6 @@ class AmiSymbolFacade:
 class AmiHeaderFacade:
     def __init__(self):
         pass
-
-
-def reverse_bits(byte_data):
-    return int("{:08b}".format(byte_data)[::-1], 2)
-
-
-def read_date(date_tuple):
-    values = int.from_bytes(bytes(date_tuple), "little")
-    return {
-        YEAR: values >> 52,
-        MONTH: (values >> 48) & 0x0F,
-        DAY: (values >> 43) & 0x1F,
-        HOUR: (values >> 38) & 0x1F,
-        MINUTE: (values >> 32) & 0x3F,
-        SECOND: (values >> 26) & 0x3F,
-        MILLI_SEC: (values >> 16) & 0x3FF,
-        MICRO_SEC: (values >> 6) & 0x3FF,
-        RESERVED: values & 0xE,
-        FUT: values & 0x1,
-    }
-
 
 def read_date_data(entrybin):
     stride = 40

--- a/ami2py/bitparser.py
+++ b/ami2py/bitparser.py
@@ -1,0 +1,18 @@
+import os
+
+USE_RUST = os.environ.get("AMI2PY_USE_RUST", "0") == "1"
+
+if USE_RUST:
+    try:
+        from . import rust_bitparser as _backend
+    except Exception:  # pragma: no cover - rust module may not be built
+        USE_RUST = False
+        from . import py_bitparser as _backend
+else:
+    from . import py_bitparser as _backend
+
+reverse_bits = _backend.reverse_bits
+read_date = _backend.read_date
+create_float = getattr(_backend, "create_float", None)
+float_to_bin = getattr(_backend, "float_to_bin", None)
+date_to_bin = getattr(_backend, "date_to_bin", None)

--- a/ami2py/py_bitparser.py
+++ b/ami2py/py_bitparser.py
@@ -1,0 +1,49 @@
+import struct
+from .consts import (
+    YEAR,
+    MONTH,
+    DAY,
+    HOUR,
+    MINUTE,
+    SECOND,
+    MILLI_SEC,
+    MICRO_SEC,
+    RESERVED,
+    FUT,
+)
+
+def reverse_bits(byte_data: int) -> int:
+    return int("{:08b}".format(byte_data)[::-1], 2)
+
+
+def read_date(date_tuple):
+    values = int.from_bytes(bytes(date_tuple), "little")
+    return {
+        YEAR: values >> 52,
+        MONTH: (values >> 48) & 0x0F,
+        DAY: (values >> 43) & 0x1F,
+        HOUR: (values >> 38) & 0x1F,
+        MINUTE: (values >> 32) & 0x3F,
+        SECOND: (values >> 26) & 0x3F,
+        MILLI_SEC: (values >> 16) & 0x3FF,
+        MICRO_SEC: (values >> 6) & 0x3FF,
+        RESERVED: values & 0xE,
+        FUT: values & 0x1,
+    }
+
+
+def create_float(float_tuple):
+    return struct.unpack("<f", bytes(float_tuple))[0]
+
+
+def float_to_bin(data: float) -> bytearray:
+    return bytearray(struct.pack("<f", data))
+
+
+def date_to_bin(day, month, year, hour=0, minute=0, second=0, mic_sec=0, milli_sec=0):
+    result = bytearray(8)
+    result[7] = year >> 4
+    result[6] = (result[6] & 0x0F) + (year << 4) & 0xF0
+    result[6] = (result[6] & 0xF0) + month
+    result[5] = (day << 3) + result[5] & 0xF8
+    return result

--- a/rust_bitparser/Cargo.toml
+++ b/rust_bitparser/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_bitparser"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+name = "rust_bitparser"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.21", features = ["extension-module"] }

--- a/rust_bitparser/src/lib.rs
+++ b/rust_bitparser/src/lib.rs
@@ -1,0 +1,37 @@
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn reverse_bits(byte_data: u8) -> u8 {
+    byte_data.reverse_bits()
+}
+
+#[pyfunction]
+fn read_date(date_tuple: Vec<u8>) -> PyResult<PyObject> {
+    if date_tuple.len() < 8 {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>("expected 8 bytes"));
+    }
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&date_tuple[..8]);
+    let value = u64::from_le_bytes(bytes);
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let dict = PyDict::new(py);
+    dict.set_item("Year", value >> 52)?;
+    dict.set_item("Month", (value >> 48) & 0x0Fu64)?;
+    dict.set_item("Day", (value >> 43) & 0x1Fu64)?;
+    dict.set_item("Hour", (value >> 38) & 0x1Fu64)?;
+    dict.set_item("Minute", (value >> 32) & 0x3Fu64)?;
+    dict.set_item("Second", (value >> 26) & 0x3Fu64)?;
+    dict.set_item("MilliSec", (value >> 16) & 0x3FFu64)?;
+    dict.set_item("MicroSec", (value >> 6) & 0x3FFu64)?;
+    dict.set_item("Reserved", value & 0xEu64)?;
+    dict.set_item("Isfut", value & 0x1u64)?;
+    Ok(dict.to_object(py))
+}
+
+#[pymodule]
+fn rust_bitparser(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(reverse_bits, m)?)?;
+    m.add_function(wrap_pyfunction!(read_date, m)?)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- introduce Rust crate `rust_bitparser` with PyO3 bindings
- provide a `bitparser` module selecting Python or Rust backend via `AMI2PY_USE_RUST`
- refactor `AmiSymbolFacade` to use the new bit parser
- document the optional backend in README

## Testing
- `python -m py_compile ami2py/bitparser.py ami2py/py_bitparser.py rust_bitparser/src/lib.rs`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'construct')*