### PR TITLE
Configure Cargo for offline builds

### DIFF
--- a/rust_bitparser/.cargo/config.toml
+++ b/rust_bitparser/.cargo/config.toml
@@ -1,0 +1,8 @@
+[net]
+offline = true
+
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"


### PR DESCRIPTION
## Summary
- ensure Cargo does not attempt network access by default
- add configuration to look for vendored crates in `vendor`

## Testing
- `bash run_tests.sh`