### PR TITLE
Ensure tests use Rust backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ rust_bitparser/target/
 rust_bitparser/Cargo.lock
 rust_bitparser/vendor/
 tests/NewData/
+ami2py/rust_bitparser.so

--- a/README.md
+++ b/README.md
@@ -183,3 +183,12 @@ The bit parsing logic can optionally be executed using a Rust implementation. Se
 `AMI2PY_USE_RUST=1` in the environment to activate the Rust backend (requires the
 `rust_bitparser` extension to be built). If the extension is not available, the
 library falls back to the pure Python implementation.
+
+The included `run_tests.sh` script automatically compiles the Rust extension in offline mode before running the tests. If you want to build it manually, execute:
+
+```bash
+cargo build --manifest-path rust_bitparser/Cargo.toml --release --offline
+cp rust_bitparser/target/release/librust_bitparser.so ami2py/rust_bitparser.so
+```
+
+This will make the Rust backend available when `AMI2PY_USE_RUST=1` is set.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,1 +1,14 @@
-pytest
+#!/usr/bin/env bash
+set -e
+
+# Build the Rust extension in offline mode
+CARGO_FLAGS="--manifest-path rust_bitparser/Cargo.toml --release --offline"
+
+if [ ! -f rust_bitparser/target/release/librust_bitparser.so ]; then
+    cargo build $CARGO_FLAGS
+fi
+
+# Copy the compiled library next to the Python sources
+cp rust_bitparser/target/release/librust_bitparser.so ami2py/rust_bitparser.so
+
+pytest "$@"


### PR DESCRIPTION
## Summary
- update `run_tests.sh` to build the Rust extension before running tests
- ignore the compiled `rust_bitparser.so`
- document how to build the Rust extension in README

## Testing
- `./run_tests.sh -q`
