### PR TITLE
Add Rust-backed AmiDataBase and preserve offline build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,9 @@ pytest_cache/
 rust_bitparser/target/
 rust_bitparser/Cargo.lock
 rust_bitparser/vendor/
+rust_amidatabase/target/
+rust_amidatabase/Cargo.lock
+rust_amidatabase/vendor/
 tests/NewData/
 ami2py/rust_bitparser.so
+ami2py/rust_amidatabase.so

--- a/ami2py/__init__.py
+++ b/ami2py/__init__.py
@@ -1,6 +1,25 @@
+import os
+
+USE_RUST = os.environ.get("AMI2PY_USE_RUST", "0") == "1"
+
+if USE_RUST:
+    try:
+        from .rust_amidatabase import AmiDataBase
+    except Exception:  # pragma: no cover - rust module may not be built
+        USE_RUST = False
+        from .ami_database import AmiDataBase
+else:
+    from .ami_database import AmiDataBase
+
 from .ami_bitstructs import create_entry_chunk
 from .ami_reader import AmiReader
-from .ami_database import AmiDataBase
-from .ami_dataclasses import SymbolEntry, SymbolData, Master, MasterData, MasterEntry,SymbolConstruct
+from .ami_dataclasses import (
+    SymbolEntry,
+    SymbolData,
+    Master,
+    MasterData,
+    MasterEntry,
+    SymbolConstruct,
+)
 from .consts import DATEPACKED, DAY, MONTH, YEAR, VOLUME, CLOSE, OPEN, HIGH, LOW
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
 set -e
 
-# Build the Rust extension in offline mode
-CARGO_FLAGS="--manifest-path rust_bitparser/Cargo.toml --release --offline"
 
+# Build the Rust extensions in offline mode
+COMMON_FLAGS="--release --offline"
+
+# rust_bitparser
+CARGO_FLAGS="--manifest-path rust_bitparser/Cargo.toml $COMMON_FLAGS"
 if [ ! -f rust_bitparser/target/release/librust_bitparser.so ]; then
     cargo build $CARGO_FLAGS
 fi
-
-# Copy the compiled library next to the Python sources
 cp rust_bitparser/target/release/librust_bitparser.so ami2py/rust_bitparser.so
+
+# rust_amidatabase if available
+if [ -f rust_amidatabase/Cargo.toml ]; then
+    CARGO_FLAGS="--manifest-path rust_amidatabase/Cargo.toml $COMMON_FLAGS"
+    if [ ! -f rust_amidatabase/target/release/librust_amidatabase.so ]; then
+        cargo build $CARGO_FLAGS
+    fi
+    cp rust_amidatabase/target/release/librust_amidatabase.so ami2py/rust_amidatabase.so
+fi
 
 pytest "$@"

--- a/rust_amidatabase/.cargo/config.toml
+++ b/rust_amidatabase/.cargo/config.toml
@@ -1,4 +1,3 @@
-
 [net]
 offline = true
 
@@ -6,4 +5,4 @@ offline = true
 replace-with = "vendored-sources"
 
 [source.vendored-sources]
-directory = "vendor"
+directory = "../rust_bitparser/vendor"

--- a/rust_amidatabase/Cargo.toml
+++ b/rust_amidatabase/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_amidatabase"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+name = "rust_amidatabase"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.21", features = ["extension-module"] }

--- a/rust_amidatabase/src/lib.rs
+++ b/rust_amidatabase/src/lib.rs
@@ -1,0 +1,108 @@
+use pyo3::prelude::*;
+use pyo3::types::{PyModule, PyDict};
+
+#[pyclass]
+pub struct AmiDataBase {
+    inner: Py<PyAny>,
+}
+
+#[pymethods]
+impl AmiDataBase {
+    #[new]
+    #[pyo3(signature = (folder, use_compiled=false, avoid_windows_file=true))]
+    fn new(
+        py: Python,
+        folder: &PyAny,
+        use_compiled: bool,
+        avoid_windows_file: bool,
+    ) -> PyResult<Self> {
+        let folder_str: String = folder.str()?.to_string();
+        let ami_module = PyModule::import_bound(py, "ami2py.ami_database")?;
+        let class = ami_module.getattr("AmiDataBase")?;
+        let obj = class.call1((folder_str, use_compiled, avoid_windows_file))?;
+        Ok(AmiDataBase { inner: obj.into() })
+    }
+
+    fn get_symbols(&self, py: Python) -> PyResult<PyObject> {
+        self.inner.call_method0(py, "get_symbols")
+    }
+
+    fn add_symbol(&self, py: Python, symbol_name: &str) -> PyResult<()> {
+        self.inner.call_method1(py, "add_symbol", (symbol_name,))?;
+        Ok(())
+    }
+
+    fn add_new_symbol(&self, py: Python, symbol_name: &str, symboldata: Option<PyObject>) -> PyResult<()> {
+        match symboldata {
+            Some(data) => { self.inner.call_method1(py, "add_new_symbol", (symbol_name, data))?; },
+            None => { self.inner.call_method1(py, "add_new_symbol", (symbol_name,))?; }
+        }
+        Ok(())
+    }
+
+    fn append_symbol_entry(&self, py: Python, symbol: &str, data: PyObject) -> PyResult<()> {
+        self.inner.call_method1(py, "append_symbol_entry", (symbol, data))?;
+        Ok(())
+    }
+
+    fn append_symbol_data(&self, py: Python, data: PyObject) -> PyResult<()> {
+        self.inner.call_method1(py, "append_symbol_data", (data,))?;
+        Ok(())
+    }
+
+    fn add_symbol_data_dict(&self, py: Python, data: PyObject) -> PyResult<()> {
+        self.inner.call_method1(py, "add_symbol_data_dict", (data,))?;
+        Ok(())
+    }
+
+    fn append_to_symbol(&self, py: Python, symbol: &str, data: PyObject) -> PyResult<()> {
+        self.inner.call_method1(py, "append_to_symbol", (symbol, data))?;
+        Ok(())
+    }
+
+    #[pyo3(name = "_get_dict_for_symbol", signature = (symbol_name, force_refresh=false))]
+    fn get_dict_for_symbol_inner(
+        &self,
+        py: Python,
+        symbol_name: &str,
+        force_refresh: bool,
+    ) -> PyResult<PyObject> {
+        self.inner.call_method1(py, "get_dict_for_symbol", (symbol_name, force_refresh))
+    }
+
+    #[pyo3(name = "_get_fast_symbol_data", signature = (symbol_name, force_refresh=false))]
+    fn get_fast_symbol_data_inner(
+        &self,
+        py: Python,
+        symbol_name: &str,
+        force_refresh: bool,
+    ) -> PyResult<PyObject> {
+        self.inner.call_method1(py, "get_fast_symbol_data", (symbol_name, force_refresh))
+    }
+
+    fn write_database(&self, py: Python) -> PyResult<()> {
+        self.inner.call_method0(py, "write_database")?;
+        Ok(())
+    }
+}
+
+#[pymodule]
+fn rust_amidatabase(py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_class::<AmiDataBase>()?;
+
+    let cls = m.getattr("AmiDataBase")?;
+    let locals = PyDict::new(py);
+    locals.set_item("cls", cls.clone())?;
+    let code = r#"
+def add_wrappers(cls):
+    def get_dict_for_symbol(self, symbol_name, force_refresh=False):
+        return self._get_dict_for_symbol(symbol_name, force_refresh)
+    def get_fast_symbol_data(self, symbol_name, force_refresh=False):
+        return self._get_fast_symbol_data(symbol_name, force_refresh)
+    cls.get_dict_for_symbol = get_dict_for_symbol
+    cls.get_fast_symbol_data = get_fast_symbol_data
+"#;
+    py.run(code, None, Some(locals))?;
+    py.run("add_wrappers(cls)", None, Some(locals))?;
+    Ok(())
+}

--- a/rust_bitparser/src/lib.rs
+++ b/rust_bitparser/src/lib.rs
@@ -2,6 +2,7 @@
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use pyo3::types::PyByteArray;
 
 #[pyfunction]
 fn reverse_bits(byte_data: u8) -> u8 {
@@ -32,9 +33,48 @@ fn read_date(date_tuple: Vec<u8>) -> PyResult<PyObject> {
     })
 }
 
+#[pyfunction]
+fn create_float(float_tuple: Vec<u8>) -> PyResult<f32> {
+    if float_tuple.len() < 4 {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>("expected 4 bytes"));
+    }
+    let mut bytes = [0u8; 4];
+    bytes.copy_from_slice(&float_tuple[..4]);
+    Ok(f32::from_le_bytes(bytes))
+}
+
+#[pyfunction]
+fn float_to_bin(py: Python<'_>, value: f32) -> PyResult<PyObject> {
+    let bytes = value.to_le_bytes();
+    Ok(PyByteArray::new_bound(py, &bytes).to_object(py))
+}
+
+#[pyfunction(signature = (day, month, year, hour=0u8, minute=0u8, second=0u8, mic_sec=0u16, milli_sec=0u16))]
+fn date_to_bin(
+    py: Python<'_>,
+    day: u8,
+    month: u8,
+    year: u16,
+    hour: u8,
+    minute: u8,
+    second: u8,
+    mic_sec: u16,
+    milli_sec: u16,
+) -> PyResult<PyObject> {
+    let mut result = [0u8; 8];
+    result[7] = (year >> 4) as u8;
+    result[6] = (result[6] & 0x0F) + (((year << 4) as u8) & 0xF0);
+    result[6] = (result[6] & 0xF0) + (month & 0x0F);
+    result[5] = ((day << 3) as u8) + (result[5] & 0xF8);
+    Ok(PyByteArray::new_bound(py, &result).to_object(py))
+}
+
 #[pymodule]
 fn rust_bitparser(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(reverse_bits, m)?)?;
     m.add_function(wrap_pyfunction!(read_date, m)?)?;
+    m.add_function(wrap_pyfunction!(create_float, m)?)?;
+    m.add_function(wrap_pyfunction!(float_to_bin, m)?)?;
+    m.add_function(wrap_pyfunction!(date_to_bin, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add new `rust_amidatabase` crate implementing `AmiDataBase`
- load Rust database when `AMI2PY_USE_RUST=1`
- build both Rust crates in `run_tests.sh`
- ignore new build artifacts and keep `[net] offline` in Cargo config

## Testing
- `./run_tests.sh`