### PR TITLE
Add intraday support in date_to_bin

### DIFF
--- a/ami2py/ami_symbol_facade.py
+++ b/ami2py/ami_symbol_facade.py
@@ -160,13 +160,33 @@ def float_to_bin(data):
     return bytearray(struct.pack("<f", data))
 
 
-def date_to_bin(day, month, year, hour=0, minute=0, second=0, mic_sec=0, milli_sec=0):
-    result = bytearray(8)
-    result[7] = year >> 4
-    result[6] = (result[6] & 0x0F) + (year << 4) & 0xF0
-    result[6] = (result[6] & 0xF0) + month
-    result[5] = (day << 3) + result[5] & 0xF8
-    return result
+def date_to_bin(
+    day: int,
+    month: int,
+    year: int,
+    hour: int = 0,
+    minute: int = 0,
+    second: int = 0,
+    mic_sec: int = 0,
+    milli_sec: int = 0,
+) -> bytearray:
+    """Convert date and time information into AmiBroker binary format."""
+
+    values = (
+        (year << 52)
+        | (month << 48)
+        | (day << 43)
+        | (hour << 38)
+        | (minute << 32)
+        | (second << 26)
+        | (milli_sec << 16)
+        | (mic_sec << 6)
+        | 0
+        | 0
+    )
+
+    byte_values = values.to_bytes(8, "little")
+    return bytearray(byte_values)
     # Currently reading intraday data is very difficult
     # YEAR: (date_tuple[7] << 4) + ((date_tuple[6] & 0xF0) >> 4),
     # MONTH: date_tuple[6] & 0x0F,

--- a/ami2py/py_bitparser.py
+++ b/ami2py/py_bitparser.py
@@ -40,10 +40,30 @@ def float_to_bin(data: float) -> bytearray:
     return bytearray(struct.pack("<f", data))
 
 
-def date_to_bin(day, month, year, hour=0, minute=0, second=0, mic_sec=0, milli_sec=0):
-    result = bytearray(8)
-    result[7] = year >> 4
-    result[6] = (result[6] & 0x0F) + (year << 4) & 0xF0
-    result[6] = (result[6] & 0xF0) + month
-    result[5] = (day << 3) + result[5] & 0xF8
-    return result
+def date_to_bin(
+    day: int,
+    month: int,
+    year: int,
+    hour: int = 0,
+    minute: int = 0,
+    second: int = 0,
+    mic_sec: int = 0,
+    milli_sec: int = 0,
+) -> bytearray:
+    """Convert date and time to AmiBroker binary representation."""
+
+    values = (
+        (year << 52)
+        | (month << 48)
+        | (day << 43)
+        | (hour << 38)
+        | (minute << 32)
+        | (second << 26)
+        | (milli_sec << 16)
+        | (mic_sec << 6)
+        | 0
+        | 0
+    )
+
+    byte_values = values.to_bytes(8, "little")
+    return bytearray(byte_values)

--- a/rust_bitparser/src/lib.rs
+++ b/rust_bitparser/src/lib.rs
@@ -61,12 +61,17 @@ fn date_to_bin(
     mic_sec: u16,
     milli_sec: u16,
 ) -> PyResult<PyObject> {
-    let mut result = [0u8; 8];
-    result[7] = (year >> 4) as u8;
-    result[6] = (result[6] & 0x0F) + (((year << 4) as u8) & 0xF0);
-    result[6] = (result[6] & 0xF0) + (month & 0x0F);
-    result[5] = ((day << 3) as u8) + (result[5] & 0xF8);
-    Ok(PyByteArray::new_bound(py, &result).to_object(py))
+    let values: u64 = ((year as u64) << 52)
+        | ((month as u64) << 48)
+        | ((day as u64) << 43)
+        | ((hour as u64) << 38)
+        | ((minute as u64) << 32)
+        | ((second as u64) << 26)
+        | ((milli_sec as u64) << 16)
+        | ((mic_sec as u64) << 6);
+
+    let byte_values = values.to_le_bytes();
+    Ok(PyByteArray::new_bound(py, &byte_values).to_object(py))
 }
 
 #[pymodule]


### PR DESCRIPTION
## Summary
- extend `date_to_bin` conversion with intraday fields
- keep Python and Rust backends consistent with new implementation

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683e136c75208333abcd321cfd03159c