### PR TITLE
Fix Rust build for GitHub Actions

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,12 +3,12 @@ set -e
 
 
 # Build the Rust extensions
-if [ -n "${CIRCLECI:-}" ]; then
-    # CircleCI has network access, disable any offline config
+if [ -n "${CIRCLECI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
+    # CI environments have network access, disable any offline config
     export CARGO_NET_OFFLINE=false
     COMMON_FLAGS="--release"
 else
-    # Default to offline mode for local environments
+    # Default to offline mode for local environments to support Codex
     COMMON_FLAGS="--release --offline"
 fi
 


### PR DESCRIPTION
## Summary
- ensure run_tests.sh disables offline mode for GitHub Actions

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683ed767cd548333b6762ff67215c122