### PR TITLE
Fix Windows build for Rust extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,8 @@ rust_amireader/target/
 rust_amireader/Cargo.lock
 tests/NewData/
 ami2py/rust_bitparser.so
+ami2py/rust_bitparser.pyd
 ami2py/rust_amidatabase.so
+ami2py/rust_amidatabase.pyd
+ami2py/rust_amireader.so
+ami2py/rust_amireader.pyd

--- a/README.md
+++ b/README.md
@@ -203,7 +203,10 @@ The included `run_tests.sh` script automatically compiles the Rust extension bef
 
 ```bash
 cargo build --manifest-path rust_bitparser/Cargo.toml --release --offline
+# Linux/macOS
 cp rust_bitparser/target/release/librust_bitparser.so ami2py/rust_bitparser.so
+# Windows
+cp rust_bitparser/target/release/rust_bitparser.dll ami2py/rust_bitparser.pyd
 ```
 
 This will make the Rust backend available when `AMI2PY_USE_RUST=1` is set.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,27 +14,54 @@ fi
 
 # rust_bitparser
 CARGO_FLAGS="--manifest-path rust_bitparser/Cargo.toml $COMMON_FLAGS"
-if [ ! -f rust_bitparser/target/release/librust_bitparser.so ]; then
+
+# Determine platform specific library names
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        LIB_PREFIX=""
+        LIB_SUFFIX=".dll"
+        DEST_EXT=".pyd"
+        ;;
+    Darwin*)
+        LIB_PREFIX="lib"
+        LIB_SUFFIX=".dylib"
+        DEST_EXT=".so"
+        ;;
+    *)
+        LIB_PREFIX="lib"
+        LIB_SUFFIX=".so"
+        DEST_EXT=".so"
+        ;;
+esac
+
+RUST_LIB="rust_bitparser/target/release/${LIB_PREFIX}rust_bitparser${LIB_SUFFIX}"
+DEST_LIB="ami2py/rust_bitparser${DEST_EXT}"
+
+if [ ! -f "$RUST_LIB" ]; then
     cargo build $CARGO_FLAGS
 fi
-cp rust_bitparser/target/release/librust_bitparser.so ami2py/rust_bitparser.so
+cp "$RUST_LIB" "$DEST_LIB"
 
 # rust_amidatabase if available
 if [ -f rust_amidatabase/Cargo.toml ]; then
     CARGO_FLAGS="--manifest-path rust_amidatabase/Cargo.toml $COMMON_FLAGS"
-    if [ ! -f rust_amidatabase/target/release/librust_amidatabase.so ]; then
+    RUST_LIB="rust_amidatabase/target/release/${LIB_PREFIX}rust_amidatabase${LIB_SUFFIX}"
+    DEST_LIB="ami2py/rust_amidatabase${DEST_EXT}"
+    if [ ! -f "$RUST_LIB" ]; then
         cargo build $CARGO_FLAGS
     fi
-    cp rust_amidatabase/target/release/librust_amidatabase.so ami2py/rust_amidatabase.so
+    cp "$RUST_LIB" "$DEST_LIB"
 fi
 
 # rust_amireader if available
 if [ -f rust_amireader/Cargo.toml ]; then
     CARGO_FLAGS="--manifest-path rust_amireader/Cargo.toml $COMMON_FLAGS"
-    if [ ! -f rust_amireader/target/release/librust_amireader.so ]; then
+    RUST_LIB="rust_amireader/target/release/${LIB_PREFIX}rust_amireader${LIB_SUFFIX}"
+    DEST_LIB="ami2py/rust_amireader${DEST_EXT}"
+    if [ ! -f "$RUST_LIB" ]; then
         cargo build $CARGO_FLAGS
     fi
-    cp rust_amireader/target/release/librust_amireader.so ami2py/rust_amireader.so
+    cp "$RUST_LIB" "$DEST_LIB"
 fi
 
 pytest "$@"


### PR DESCRIPTION
## Summary
- make test script platform-aware when copying Rust libraries
- mention Windows commands in the README
- ignore Windows build artefacts

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683ee80984d88333bbf05e327873ff7a