### PR TITLE
Fix pytest invocation in run_tests script

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -64,4 +64,4 @@ if [ -f rust_amireader/Cargo.toml ]; then
     cp "$RUST_LIB" "$DEST_LIB"
 fi
 
-pytest "$@"
+python -m pytest "$@"


### PR DESCRIPTION
## Summary
- ensure tests run with `python -m pytest`

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683ef25667508333ae84b0eb41f50e5f