### PR TITLE
Fix optional CLI script packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,6 @@ setup(
         'construct==2.10.67',
         'dataclass-type-validator'
     ],
-    # Install the compiled CLI alongside the Python package
-    # scripts=[AMI_CLI_BIN]
+    # Install the compiled CLI alongside the Python package if it was built
+    scripts=[AMI_CLI_BIN] if os.path.exists(AMI_CLI_BIN) else [],
 )


### PR DESCRIPTION
## Summary
- fix `setup.py` to only include CLI binary if it exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ef4d02d808333805898be2041b9b4