### PR TITLE
Fix build_whl virtualenv activation

### DIFF
--- a/scripts/build_whl.sh
+++ b/scripts/build_whl.sh
@@ -35,8 +35,15 @@ else
 fi
 
 # Create and activate virtual environment
-"$PY" -m venv "$BOOT_DIR/venv"
-source "$BOOT_DIR/venv/bin/activate"
+VENV_DIR="$BOOT_DIR/venv"
+"$PY" -m venv "$VENV_DIR"
+if [ -f "$VENV_DIR/Scripts/activate" ]; then
+    # Windows virtualenv layout
+    source "$VENV_DIR/Scripts/activate"
+else
+    # POSIX virtualenv layout
+    source "$VENV_DIR/bin/activate"
+fi
 pip install --upgrade pip build wheel >/dev/null
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fix venv activation on Windows by probing `Scripts/activate`
- ensure compatibility with POSIX layout

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683efb89fbf483339e37baf6d7400356