### PR TITLE
Fix Python fallback for build script

### DIFF
--- a/scripts/build_whl.sh
+++ b/scripts/build_whl.sh
@@ -19,6 +19,8 @@ fetch() {
 # Ensure Python
 if command -v python3 >/dev/null 2>&1; then
     PY=$(command -v python3)
+elif command -v python >/dev/null 2>&1; then
+    PY=$(command -v python)
 else
     PYVER="3.11.6"
     PYDIR="$BOOT_DIR/python"


### PR DESCRIPTION
## Summary
- ensure build script uses `python` when `python3` isn't found

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683efd202d00833393b18a92f6ce822a