### PR TITLE
Fix Windows python path in build script

### DIFF
--- a/scripts/build_whl.sh
+++ b/scripts/build_whl.sh
@@ -40,6 +40,16 @@ else
 fi
 echo "Using Python at $PY" >&2
 
+# On Windows, command -v may return a path without the required extension.
+# Add '.exe' or '.bat' if those files exist so the executable can be invoked
+if [ ! -f "$PY" ]; then
+    if [ -f "${PY}.exe" ]; then
+        PY="${PY}.exe"
+    elif [ -f "${PY}.bat" ]; then
+        PY="${PY}.bat"
+    fi
+fi
+
 # Create and activate virtual environment
 VENV_DIR="$BOOT_DIR/venv"
 echo "Creating virtual environment in $VENV_DIR" >&2


### PR DESCRIPTION
## Summary
- ensure `build_whl.sh` resolves Python executable on Windows
- add fallback to `.exe` or `.bat` when running with a shim path

## Testing
- `./run_tests.sh`
- `./scripts/build_whl.sh` *(fails: no network access to install python packages)*

------
https://chatgpt.com/codex/tasks/task_e_683f16a4144c833390b57adc4bf427ef