### PR TITLE
Improve venv creation in wheel build

### DIFF
--- a/scripts/build_whl.sh
+++ b/scripts/build_whl.sh
@@ -67,6 +67,15 @@ fi
 VENV_DIR="$BOOT_DIR/venv"
 echo "Creating virtual environment in $VENV_DIR" >&2
 "$PY" -m venv "$VENV_DIR"
+# Some python installations (e.g. those created with `pyvenv`) do not
+# include the usual activation scripts.  If they are missing, retry
+# using `virtualenv` which always provides them.
+if [ ! -f "$VENV_DIR/bin/activate" ] && [ ! -f "$VENV_DIR/Scripts/activate" ]; then
+    echo "Virtualenv missing activate script, recreating using virtualenv" >&2
+    "$PY" -m pip install --upgrade virtualenv >/dev/null
+    rm -rf "$VENV_DIR"
+    "$PY" -m virtualenv "$VENV_DIR" >/dev/null
+fi
 if [ -f "$VENV_DIR/Scripts/activate" ]; then
     # Windows virtualenv layout
     echo "Activating Windows virtualenv" >&2


### PR DESCRIPTION
## Summary
- ensure `scripts/build_whl.sh` re-creates the virtualenv with `virtualenv` if activate scripts are missing

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f5c8e67ac8333ae929bd20a3d2005