### PR TITLE
Add CircleCI release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,25 @@ jobs:
       - run: pip install -r requirements.txt
       - run: pip install .
       - run: ./run_tests.sh
+
+  release:
+    docker:
+      - image: cimg/python:3.11
+    steps:
+      - checkout
+      - run: pip install -r requirements.txt
+      - run: pip install .
+      - run: ./scripts/build_whl.sh
+      - run: python scripts/github_release.py dist/*.whl
 workflows:
   build_and_test:
     jobs:
       - build
+  release_flow:
+    jobs:
+      - release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/scripts/github_release.py
+++ b/scripts/github_release.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import os
+import sys
+import json
+import urllib.request
+import urllib.error
+
+TOKEN = os.environ.get("GITHUB_TOKEN")
+TAG = os.environ.get("CIRCLE_TAG")
+REPO_USER = os.environ.get("CIRCLE_PROJECT_USERNAME")
+REPO_NAME = os.environ.get("CIRCLE_PROJECT_REPONAME")
+
+if not TOKEN:
+    print("GITHUB_TOKEN is not set", file=sys.stderr)
+    sys.exit(1)
+if not TAG:
+    print("CIRCLE_TAG is not set; skipping release", file=sys.stderr)
+    sys.exit(0)
+if not REPO_USER or not REPO_NAME:
+    print("Repository information missing", file=sys.stderr)
+    sys.exit(1)
+
+repo = f"{REPO_USER}/{REPO_NAME}"
+url = f"https://api.github.com/repos/{repo}/releases"
+
+payload = {
+    "tag_name": TAG,
+    "name": TAG,
+    "draft": False,
+    "prerelease": False,
+}
+
+data = json.dumps(payload).encode()
+request = urllib.request.Request(url, data=data,
+                                 headers={"Authorization": f"token {TOKEN}",
+                                          "Content-Type": "application/json"})
+try:
+    with urllib.request.urlopen(request) as resp:
+        resp_data = json.load(resp)
+except urllib.error.HTTPError as exc:
+    print(f"Failed to create release: {exc.read().decode()}", file=sys.stderr)
+    raise
+
+upload_url = resp_data.get("upload_url", "").split("{")[0]
+
+for path in sys.argv[1:]:
+    filename = os.path.basename(path)
+    with open(path, "rb") as f:
+        file_data = f.read()
+    upload_request = urllib.request.Request(
+        f"{upload_url}?name={filename}", data=file_data,
+        headers={
+            "Authorization": f"token {TOKEN}",
+            "Content-Type": "application/octet-stream",
+        }
+    )
+    try:
+        with urllib.request.urlopen(upload_request) as resp:
+            resp.read()
+    except urllib.error.HTTPError as exc:
+        print(f"Failed to upload {filename}: {exc.read().decode()}", file=sys.stderr)
+        raise


### PR DESCRIPTION
## Summary
- add a script that publishes GitHub releases
- update CircleCI config to build wheels and create releases when tags are pushed

## Testing
- `./run_tests.sh`
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6a89b19c83338b08d3be1c7cb806