### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.10.0
 tag = True
 commit = True
 message = Bump version: {current_version} -> {new_version} [ci skip]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ami2py"
-version = "0.9.0"
+version = "0.10.0"
 description = "Python Package for reading a amibroker database"
 authors = [{name = "Dark Ligt alias FB2011B"}]
 license = {file = "LICENSE"}

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def long_description():
 
 setup(
     name="ami2py",
-    version="0.9.0",
+    version="0.10.0",
     packages=find_packages("."),
     package_dir={"": "."},
     include_package_data=True,


### PR DESCRIPTION
## Summary
- bump minor version to 0.10.0

## Testing
- `bash run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f6fac9b4c83338ff6eb00ed4654a9