### PR TITLE
Fix setup path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ ami2py/rust_amidatabase.so
 ami2py/rust_amidatabase.pyd
 ami2py/rust_amireader.so
 ami2py/rust_amireader.pyd
+
+# Ignore compiled CLI binaries
+ami_cli/bin/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
 ]
+
+[tool.setuptools.package-data]
+"ami_cli" = ["bin/ami_cli*"]

--- a/scripts/build_whl.sh
+++ b/scripts/build_whl.sh
@@ -194,8 +194,15 @@ if [ ! -f "$CLI_BIN" ]; then
 fi
 echo "Built CLI binary at $CLI_BIN" >&2
 
+# Copy binary into package directory with a stable relative path
+BIN_DIR="$ROOT_DIR/ami_cli/bin"
+INSTALL_BIN="$BIN_DIR/ami_cli${BIN_EXT}"
+mkdir -p "$BIN_DIR"
+cp "$CLI_BIN" "$INSTALL_BIN"
+REL_CLI_BIN="ami_cli/bin/ami_cli${BIN_EXT}"
+
 # Build wheel
-export AMI_CLI_BIN="$CLI_BIN"
+export AMI_CLI_BIN="$REL_CLI_BIN"
 cd "$ROOT_DIR"
 echo "Building wheel" >&2
 python -m build --wheel

--- a/setup.py
+++ b/setup.py
@@ -6,23 +6,25 @@ Setup script for ami2py
 
 import os
 import sys
+from pathlib import Path
 
 from setuptools import setup, find_packages
 
 
-BASE_PATH = os.path.dirname(os.path.abspath(__file__))
+BASE_PATH = Path(__file__).resolve().parent
 
 # Determine the path to the compiled CLI binary. This can be overridden via
 # the AMI_CLI_BIN environment variable during the build process.
 AMI_CLI_BIN = os.environ.get("AMI_CLI_BIN")
 if AMI_CLI_BIN:
-    # setuptools requires paths relative to this file and forward slashes
-    if os.path.isabs(AMI_CLI_BIN):
-        AMI_CLI_BIN = os.path.relpath(AMI_CLI_BIN, BASE_PATH)
-    AMI_CLI_BIN = AMI_CLI_BIN.replace(os.path.sep, "/")
+    p = Path(AMI_CLI_BIN)
 else:
     exe_name = "ami_cli.exe" if os.name == "nt" else "ami_cli"
-    AMI_CLI_BIN = os.path.join("ami_cli", "target", "release", exe_name)
+    p = Path("ami_cli") / "bin" / exe_name
+
+if p.is_absolute():
+    p = p.relative_to(BASE_PATH)
+AMI_CLI_BIN = p.as_posix()
 
 
 if sys.version_info < (3, 6):
@@ -40,7 +42,10 @@ setup(
     packages=find_packages("."),
     package_dir={"": "."},
     include_package_data=True,
-    package_data={"ami2py": ["py.typed"]},
+    package_data={
+        "ami2py": ["py.typed"],
+        "ami_cli": ["bin/ami_cli*"]
+    },
     python_requires=">= 3.6",
     license="MIT",
     # install_requires=["setuptools", "pip", "docutils", "purepng>=0.1.1"],


### PR DESCRIPTION
## Summary
- add `ami_cli` binary to package data
- move CLI binary to `ami_cli/bin` during wheel build
- ensure all paths are relative and use POSIX format
- ignore generated CLI binary

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684045f3d2608333898e83960f5fe49d