### PR TITLE
Fix rust backend compile errors and new DB creation

### DIFF
--- a/rust_amidatabase/src/lib.rs
+++ b/rust_amidatabase/src/lib.rs
@@ -14,6 +14,9 @@ pub struct AmiDataBase {
 
 impl AmiDataBase {
     pub fn new(folder: &str) -> std::io::Result<Self> {
+        if !Path::new(folder).exists() {
+            fs::create_dir_all(folder)?;
+        }
         let reader = AmiReader::new(folder)?;
         Ok(AmiDataBase { folder: folder.to_string(), reader })
     }
@@ -29,7 +32,7 @@ impl AmiDataBase {
             if let Some(parent) = symbol_file.parent() {
                 fs::create_dir_all(parent)?;
             }
-            OpenOptions::new().create(true).write(true).open(&symbol_file)?;
+            // do not create an empty file here; file will be created when data is written
             self.reader.symbols.push(symbol.to_string());
         }
         Ok(())

--- a/rust_amidatabase_py/src/lib.rs
+++ b/rust_amidatabase_py/src/lib.rs
@@ -1,6 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyModule};
-use rust_amidatabase as base;
+use ::rust_amidatabase as base;
 
 #[pyclass]
 pub struct AmiDataBase {
@@ -30,7 +30,7 @@ impl AmiDataBase {
         self.py_api.call_method0(py, "get_symbols")
     }
 
-    fn add_symbol(&self, py: Python, symbol_name: &str) -> PyResult<()> {
+    fn add_symbol(&mut self, py: Python, symbol_name: &str) -> PyResult<()> {
         self.inner.add_symbol(symbol_name).map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
         self.py_api.call_method1(py, "add_symbol", (symbol_name,))?;
         Ok(())

--- a/rust_amireader/src/lib.rs
+++ b/rust_amireader/src/lib.rs
@@ -10,7 +10,11 @@ pub struct AmiReader {
 impl AmiReader {
     pub fn new(folder: &str) -> std::io::Result<Self> {
         let path = Path::new(folder).join("broker.master");
-        let data = fs::read(&path)?;
+        let data = match fs::read(&path) {
+            Ok(d) => d,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+            Err(e) => return Err(e),
+        };
         let (_, symbols) = parse_master(&data);
         Ok(AmiReader { folder: folder.to_string(), symbols })
     }

--- a/rust_amireader_py/src/lib.rs
+++ b/rust_amireader_py/src/lib.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
 use std::fs;
 use std::path::Path;
-use rust_amireader as base;
+use ::rust_amireader as base;
 
 const MASTER_ENTRY_SIZE: usize = 1172;
 const SYMBOL_HEADER_SIZE: usize = 0x4A0; // 1184
@@ -18,7 +18,7 @@ pub struct AmiReader {
 impl AmiReader {
     #[new]
     #[pyo3(signature = (folder, use_compiled=false))]
-    fn new(py: Python<'_>, folder: &str, _use_compiled: bool) -> PyResult<Self> {
+    fn new(py: Python<'_>, folder: &str, use_compiled: bool) -> PyResult<Self> {
         let inner = base::AmiReader::new(folder).map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
         let path = Path::new(folder).join("broker.master");
         let data = fs::read(&path).map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;

--- a/rust_bitparser_py/src/lib.rs
+++ b/rust_bitparser_py/src/lib.rs
@@ -2,7 +2,7 @@
 
 use pyo3::prelude::*;
 use pyo3::types::{PyByteArray, PyDict};
-use rust_bitparser as base;
+use ::rust_bitparser as base;
 
 #[pyfunction]
 fn reverse_bits(byte_data: u8) -> u8 {


### PR DESCRIPTION
## Summary
- resolve ambiguous crate imports
- allow creating databases when `broker.master` is missing
- avoid creating empty symbol files
- adjust wrapper signatures for mutability and parameter names

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840b0594ba48333a807e556ce273e9a