### PR TITLE
Implement quote handling in Rust CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ ami2py/rust_amireader.pyd
 
 # Ignore compiled CLI binaries
 ami_cli/bin/
+ami_cli/target/
+ami_cli/Cargo.lock
 rust_bitparser/target/
 rust_amireader/target/
 rust_amidatabase/target/

--- a/ami_cli/src/main.rs
+++ b/ami_cli/src/main.rs
@@ -7,6 +7,9 @@ fn usage() {
     eprintln!("  create <db_path> <symbol1> [symbol2 ...]");
     eprintln!("  add-symbol <db_path> <symbol1> [symbol2 ...]");
     eprintln!("  list-symbols <db_path>");
+    eprintln!("  get_last_time_stamp <db_path> <symbol>");
+    eprintln!("  list-quotes <db_path> <symbol> [start YYYY-MM-DD end YYYY-MM-DD]");
+    eprintln!("  add-quotes <db_path> <symbol> <csv_file>");
 }
 
 fn main() {
@@ -31,6 +34,45 @@ fn main() {
             let db = AmiDataBase::new(&args[2]).expect("open db");
             for s in db.get_symbols() { println!("{}", s); }
         }
+        "get_last_time_stamp" => {
+            if args.len() != 4 { usage(); return; }
+            let db = AmiDataBase::new(&args[2]).expect("open db");
+            match db.get_last_time_stamp(&args[3]).expect("read symbol") {
+                Some((y,m,d)) => println!("{:04}-{:02}-{:02}", y, m, d),
+                None => println!("no data"),
+            }
+        }
+        "list-quotes" => {
+            if args.len() != 4 && args.len() != 8 { usage(); return; }
+            let db = AmiDataBase::new(&args[2]).expect("open db");
+            let quotes = db.list_quotes(&args[3]).expect("read symbol");
+            let mut start = None;
+            let mut end = None;
+            if args.len() == 8 {
+                if args[4] == "start" { start = parse_date(&args[5]); }
+                if args[6] == "end" { end = parse_date(&args[7]); }
+            }
+            for q in &quotes {
+                let val = q.year as i32 * 10000 + q.month as i32 * 100 + q.day as i32;
+                if start.map_or(true, |s| val >= s) && end.map_or(true, |e| val <= e) {
+                    println!("{:04}-{:02}-{:02},{},{},{},{},{}", q.year, q.month, q.day, q.open, q.high, q.low, q.close, q.volume);
+                }
+            }
+        }
+        "add-quotes" => {
+            if args.len() != 5 { usage(); return; }
+            let db = AmiDataBase::new(&args[2]).expect("open db");
+            db.add_quotes_from_csv(&args[3], &args[4]).expect("add quotes");
+        }
         _ => usage(),
     }
+}
+
+fn parse_date(s: &str) -> Option<i32> {
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() != 3 { return None; }
+    let y: i32 = parts[0].parse().ok()?;
+    let m: i32 = parts[1].parse().ok()?;
+    let d: i32 = parts[2].parse().ok()?;
+    Some(y * 10000 + m * 100 + d)
 }

--- a/rust_amidatabase/src/lib.rs
+++ b/rust_amidatabase/src/lib.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
-use rust_amireader::AmiReader;
+use rust_amireader::{AmiReader, Quote};
 
 pub mod reader {
     pub use rust_amireader::AmiReader;
@@ -47,6 +47,60 @@ impl AmiDataBase {
             f.write_all(b"AMI2PY")?; // placeholder
         }
         Ok(())
+    }
+
+    pub fn get_last_time_stamp(&self, symbol: &str) -> std::io::Result<Option<(u16, u8, u8)>> {
+        self.reader.last_time_stamp(symbol)
+    }
+
+    pub fn list_quotes(&self, symbol: &str) -> std::io::Result<Vec<Quote>> {
+        self.reader.read_quotes(symbol)
+    }
+
+    pub fn add_quotes(&self, symbol: &str, quotes: &[Quote]) -> std::io::Result<()> {
+        self.reader.append_quotes(symbol, quotes)
+    }
+
+    pub fn add_quotes_from_csv(&self, symbol: &str, csv_path: &str) -> std::io::Result<()> {
+        let content = fs::read_to_string(csv_path)?;
+        let mut quotes = Vec::new();
+        for (i, line) in content.lines().enumerate() {
+            if i == 0 { continue; }
+            let parts: Vec<&str> = line.split(',').collect();
+            if parts.len() < 6 { continue; }
+            let date_parts: Vec<&str> = parts[0].split('-').collect();
+            if date_parts.len() != 3 { continue; }
+            let year: u16 = date_parts[0].parse().unwrap_or(0);
+            let month: u8 = date_parts[1].parse().unwrap_or(0);
+            let day: u8 = date_parts[2].parse().unwrap_or(0);
+            let open: f32 = parts[1].parse().unwrap_or(0.0);
+            let high: f32 = parts[2].parse().unwrap_or(0.0);
+            let low: f32 = parts[3].parse().unwrap_or(0.0);
+            let close: f32 = parts[4].parse().unwrap_or(0.0);
+            let volume_idx = if parts.len() > 6 { 6 } else { 5 };
+            let volume: f32 = parts[volume_idx].parse().unwrap_or(0.0);
+            quotes.push(Quote {
+                day,
+                month,
+                year,
+                hour: 0,
+                minute: 0,
+                second: 0,
+                milli_sec: 0,
+                micro_sec: 0,
+                reserved: 0,
+                future: 0,
+                close,
+                open,
+                high,
+                low,
+                volume,
+                aux1: 0.0,
+                aux2: 0.0,
+                terminator: 0.0,
+            });
+        }
+        self.add_quotes(symbol, &quotes)
     }
 }
 

--- a/rust_amireader/src/lib.rs
+++ b/rust_amireader/src/lib.rs
@@ -1,4 +1,5 @@
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::Path;
 
 #[derive(Debug)]
@@ -7,6 +8,30 @@ pub struct AmiReader {
     pub symbols: Vec<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct Quote {
+    pub day: u8,
+    pub month: u8,
+    pub year: u16,
+    pub hour: u8,
+    pub minute: u8,
+    pub second: u8,
+    pub milli_sec: u16,
+    pub micro_sec: u16,
+    pub reserved: u8,
+    pub future: u8,
+    pub close: f32,
+    pub open: f32,
+    pub high: f32,
+    pub low: f32,
+    pub volume: f32,
+    pub aux1: f32,
+    pub aux2: f32,
+    pub terminator: f32,
+}
+
+const SYMBOL_HEADER_SIZE: usize = 0x4A0;
+pub const SYMBOL_ENTRY_SIZE: usize = 40;
 impl AmiReader {
     pub fn new(folder: &str) -> std::io::Result<Self> {
         let path = Path::new(folder).join("broker.master");
@@ -27,9 +52,83 @@ impl AmiReader {
         let p = symbol_path(&self.folder, symbol);
         fs::read(p)
     }
+
+    pub fn read_quotes(&self, symbol: &str) -> std::io::Result<Vec<Quote>> {
+        let data = self.read_symbol_bytes(symbol)?;
+        Ok(parse_symbol_entries(&data[SYMBOL_HEADER_SIZE..]))
+    }
+
+    pub fn last_time_stamp(&self, symbol: &str) -> std::io::Result<Option<(u16, u8, u8)>> {
+        let quotes = self.read_quotes(symbol)?;
+        Ok(quotes.last().map(|q| (q.year, q.month, q.day)))
+    }
+
+    pub fn append_quotes(&self, symbol: &str, quotes: &[Quote]) -> std::io::Result<()> {
+        let p = symbol_path(&self.folder, symbol);
+        let mut file = OpenOptions::new().append(true).create(true).open(p)?;
+        for q in quotes {
+            let bytes = quote_to_bytes(q);
+            file.write_all(&bytes)?;
+        }
+        Ok(())
+    }
 }
 
 const MASTER_ENTRY_SIZE: usize = 1172;
+
+fn parse_symbol_entries(data: &[u8]) -> Vec<Quote> {
+    let mut entries = Vec::new();
+    let mut offset = 0;
+    while offset + SYMBOL_ENTRY_SIZE <= data.len() {
+        let chunk = &data[offset..offset + SYMBOL_ENTRY_SIZE];
+        let val = u64::from_le_bytes(chunk[..8].try_into().unwrap());
+        let year = (val >> 52) as u16;
+        let month = ((val >> 48) & 0x0F) as u8;
+        let day = ((val >> 43) & 0x1F) as u8;
+        let hour = ((val >> 38) & 0x1F) as u8;
+        let minute = ((val >> 32) & 0x3F) as u8;
+        let second = ((val >> 26) & 0x3F) as u8;
+        let milli_sec = ((val >> 16) & 0x3FF) as u16;
+        let micro_sec = ((val >> 6) & 0x3FF) as u16;
+        let reserved = ((val & 0xE) >> 1) as u8;
+        let future = (val & 0x1) as u8;
+        let close = f32::from_le_bytes(chunk[8..12].try_into().unwrap());
+        let open = f32::from_le_bytes(chunk[12..16].try_into().unwrap());
+        let high = f32::from_le_bytes(chunk[16..20].try_into().unwrap());
+        let low = f32::from_le_bytes(chunk[20..24].try_into().unwrap());
+        let volume = f32::from_le_bytes(chunk[24..28].try_into().unwrap());
+        let aux1 = f32::from_le_bytes(chunk[28..32].try_into().unwrap());
+        let aux2 = f32::from_le_bytes(chunk[32..36].try_into().unwrap());
+        let terminator = f32::from_le_bytes(chunk[36..40].try_into().unwrap());
+        entries.push(Quote { day, month, year, hour, minute, second, milli_sec, micro_sec, reserved, future, close, open, high, low, volume, aux1, aux2, terminator });
+        offset += SYMBOL_ENTRY_SIZE;
+    }
+    entries
+}
+
+fn quote_to_bytes(q: &Quote) -> [u8; SYMBOL_ENTRY_SIZE] {
+    let mut out = [0u8; SYMBOL_ENTRY_SIZE];
+    let val: u64 = ((q.year as u64) << 52)
+        | ((q.month as u64) << 48)
+        | ((q.day as u64) << 43)
+        | ((q.hour as u64) << 38)
+        | ((q.minute as u64) << 32)
+        | ((q.second as u64) << 26)
+        | ((q.milli_sec as u64) << 16)
+        | ((q.micro_sec as u64) << 6)
+        | ((q.reserved as u64) << 1)
+        | (q.future as u64);
+    out[..8].copy_from_slice(&val.to_le_bytes());
+    out[8..12].copy_from_slice(&q.close.to_le_bytes());
+    out[12..16].copy_from_slice(&q.open.to_le_bytes());
+    out[16..20].copy_from_slice(&q.high.to_le_bytes());
+    out[20..24].copy_from_slice(&q.low.to_le_bytes());
+    out[24..28].copy_from_slice(&q.volume.to_le_bytes());
+    out[28..32].copy_from_slice(&q.aux1.to_le_bytes());
+    out[32..36].copy_from_slice(&q.aux2.to_le_bytes());
+    out[36..40].copy_from_slice(&q.terminator.to_le_bytes());
+    out
+}
 
 fn parse_master(data: &[u8]) -> (Vec<u8>, Vec<String>) {
     if data.len() < 12 { return (Vec::new(), Vec::new()); }


### PR DESCRIPTION
## Summary
- add get_last_time_stamp, list-quotes and add-quotes commands to `ami_cli`
- extend `rust_amireader` with `Quote` parsing and writing helpers
- expose quote handling via `rust_amidatabase`
- ignore `ami_cli` build artifacts

## Testing
- `cargo check --manifest-path ami_cli/Cargo.toml`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840bb7d8d0c8333a11ad8519854d2d6