### PR TITLE
Fix pyproject package data keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,4 @@ classifiers = [
 ]
 
 [tool.setuptools.package-data]
-"rust/ami_cli" = ["bin/ami_cli*"]
+"*" = ["bin/ami_cli*"]


### PR DESCRIPTION
## Summary
- correct invalid key in `[tool.setuptools.package-data]`

## Testing
- `./run_tests.sh` *(fails: No module named 'dataclass_type_validator')*

------
https://chatgpt.com/codex/tasks/task_e_68416fc925088333a4b400477dac0c6d