### PR TITLE
Add MCP server crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ rust/rust_amidatabase/target/
 rust/rust_bitparser/Cargo.lock
 rust/rust_amireader/Cargo.lock
 rust/rust_amidatabase/Cargo.lock
+mcp_server/target/
+mcp_server/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[workspace]
+resolver = "3"
+members = [
+    "rust/ami_cli",
+    "rust/rust_amidatabase",
+    "rust/rust_amidatabase_py",
+    "rust/rust_amireader",
+    "rust/rust_amireader_py",
+    "rust/rust_bitparser",
+    "rust/rust_bitparser_py",
+    "mcp_server"
+]

--- a/mcp_server/Cargo.toml
+++ b/mcp_server/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "mcp_server"
+edition = "2021"
+version = "0.1.0"
+
+[dependencies]
+mcpr = { version = "0.2", default-features = false, features = ["server", "transport_stdio"] }
+serde_json = "1"
+anyhow = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+serde = { version = "1", features = ["derive"] }
+rust_amidatabase = { path = "../rust/rust_amidatabase" }

--- a/mcp_server/src/main.rs
+++ b/mcp_server/src/main.rs
@@ -1,0 +1,80 @@
+use anyhow::Result;
+use mcpr::{
+    schema::common::ToolInputSchema,
+    server::{Server, ServerConfig},
+    transport::stdio::StdioTransport,
+    Tool,
+};
+use rust_amidatabase::AmiDataBase;
+use serde::Serialize;
+use serde_json::Value;
+use std::sync::Arc;
+
+#[derive(Serialize)]
+struct QuoteRow {
+    year: u16,
+    month: u8,
+    day: u8,
+    open: f32,
+    high: f32,
+    low: f32,
+    close: f32,
+    volume: f32,
+}
+
+fn main() -> Result<()> {
+    let cfg = ServerConfig::new()
+        .with_name("ami2py MCP Server")
+        .with_version(env!("CARGO_PKG_VERSION"))
+        .with_tool(Tool {
+            name: "list_symbols".into(),
+            description: Some("Return all symbols in an AmiBroker DB".into()),
+            input_schema: ToolInputSchema {
+                r#type: "object".into(),
+                properties: None,
+                required: None,
+            },
+        })
+        .with_tool(Tool {
+            name: "get_ohlc".into(),
+            description: Some("Return OHLCV rows for a symbol".into()),
+            input_schema: ToolInputSchema {
+                r#type: "object".into(),
+                properties: None,
+                required: None,
+            },
+        });
+
+    let mut srv: Server<StdioTransport> = Server::new(cfg);
+    let db = Arc::new(AmiDataBase::new("./db")?);
+
+    {
+        let db = db.clone();
+        srv.register_tool_handler("list_symbols", move |_params: Value| {
+            let vec = db.get_symbols().to_vec();
+            Ok(serde_json::to_value(vec)?)
+        })?;
+    }
+
+    {
+        let db = db.clone();
+        srv.register_tool_handler("get_ohlc", move |params: Value| {
+            let sym: String = params["symbol"].as_str().unwrap_or("").into();
+            let quotes = db.list_quotes(&sym)?;
+            let rows: Vec<QuoteRow> = quotes.into_iter().map(|q| QuoteRow {
+                year: q.year,
+                month: q.month,
+                day: q.day,
+                open: q.open,
+                high: q.high,
+                low: q.low,
+                close: q.close,
+                volume: q.volume,
+            }).collect();
+            Ok(serde_json::to_value(rows)?)
+        })?;
+    }
+
+    srv.start(StdioTransport::new())?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add workspace `Cargo.toml` including new server crate
- ignore build artifacts for new crate
- implement `mcp_server` using mcpr
- drop Python bridge, use pure Rust database

## Testing
- `pytest -q`
- `cargo test -p mcp_server` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68419e65ba848333b9253e1a2bfea0ef