### PR TITLE
Fix test script library path

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -13,7 +13,7 @@ else
 fi
 
 # rust_bitparser
-CARGO_FLAGS="--manifest-path rust/rust_bitparser_py/Cargo.toml $COMMON_FLAGS"
+CARGO_FLAGS="--manifest-path rust/rust_bitparser_py/Cargo.toml $COMMON_FLAGS --target-dir rust/rust_bitparser_py/target"
 
 # Determine platform specific library names
 case "$(uname -s)" in
@@ -45,7 +45,7 @@ cp "$RUST_LIB" "$DEST_LIB"
 
 # rust_amidatabase if available
 if [ -f rust/rust_amidatabase_py/Cargo.toml ]; then
-    CARGO_FLAGS="--manifest-path rust/rust_amidatabase_py/Cargo.toml $COMMON_FLAGS"
+    CARGO_FLAGS="--manifest-path rust/rust_amidatabase_py/Cargo.toml $COMMON_FLAGS --target-dir rust/rust_amidatabase_py/target"
     # rust_amidatabase if available
     RUST_LIB="rust/rust_amidatabase_py/target/release/${LIB_PREFIX}rust_amidatabase${LIB_SUFFIX}"
     DEST_LIB="ami2py/rust_amidatabase${DEST_EXT}"
@@ -57,7 +57,7 @@ fi
 
 # rust_amireader if available
 if [ -f rust/rust_amireader_py/Cargo.toml ]; then
-    CARGO_FLAGS="--manifest-path rust/rust_amireader_py/Cargo.toml $COMMON_FLAGS"
+    CARGO_FLAGS="--manifest-path rust/rust_amireader_py/Cargo.toml $COMMON_FLAGS --target-dir rust/rust_amireader_py/target"
     # rust_amireader if available
     RUST_LIB="rust/rust_amireader_py/target/release/${LIB_PREFIX}rust_amireader${LIB_SUFFIX}"
     DEST_LIB="ami2py/rust_amireader${DEST_EXT}"


### PR DESCRIPTION
## Summary
- ensure Cargo build output goes to expected crate-specific directories

## Testing
- `./scripts/run_tests.sh`
- `pre-commit run --files scripts/run_tests.sh` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841d937c9908333b58570913fc2421d