### PR TITLE
Build CLI and server on CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ __pycache__/
 *.egg-info/
 pytest_cache/
 
+# Ignore workspace lock file generated during CI
+Cargo.lock
+
 # Rust build artifacts
 rust/rust_bitparser_py/target/
 rust/rust_bitparser_py/Cargo.lock
@@ -31,3 +34,4 @@ rust/rust_amireader/Cargo.lock
 rust/rust_amidatabase/Cargo.lock
 rust/mcp_server/target/
 rust/mcp_server/Cargo.lock
+target/

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -67,4 +67,14 @@ if [ -f rust/rust_amireader_py/Cargo.toml ]; then
     cp "$RUST_LIB" "$DEST_LIB"
 fi
 
+# Build mcp_server if available
+if [ -f rust/mcp_server/Cargo.toml ]; then
+    cargo build --manifest-path rust/mcp_server/Cargo.toml $COMMON_FLAGS || true
+fi
+
+# Build ami_cli if available
+if [ -f rust/ami_cli/Cargo.toml ]; then
+    cargo build --manifest-path rust/ami_cli/Cargo.toml $COMMON_FLAGS || true
+fi
+
 python -m pytest "$@"


### PR DESCRIPTION
## Summary
- build `mcp_server` and `ami_cli` when running tests
- ignore generated Cargo artifacts

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68420b2433688333b372236690b877e2