### PR TITLE
Fix build_whl script

### DIFF
--- a/scripts/build_whl.sh
+++ b/scripts/build_whl.sh
@@ -171,12 +171,13 @@ echo "Vendoring Rust dependencies" >&2
 COMMON_FLAGS="--release --offline"
 
 # Build Rust libraries and copy them into the package
-for CRATE in rust_bitparser rust_amidatabase rust_amireader; do
+for CRATE in rust_bitparser_py rust_amidatabase_py rust_amireader_py; do
     if [ -f "$ROOT_DIR/rust/$CRATE/Cargo.toml" ]; then
+        LIB_NAME=${CRATE%_py}
         echo "Building $CRATE" >&2
         cargo build --manifest-path "$ROOT_DIR/rust/$CRATE/Cargo.toml" $COMMON_FLAGS
-        SRC_LIB="$ROOT_DIR/rust/$CRATE/target/release/${LIB_PREFIX}${CRATE}${LIB_SUFFIX}"
-        DEST_LIB="$ROOT_DIR/ami2py/${CRATE}${DEST_EXT}"
+        SRC_LIB="$ROOT_DIR/rust/$CRATE/target/release/${LIB_PREFIX}${LIB_NAME}${LIB_SUFFIX}"
+        DEST_LIB="$ROOT_DIR/ami2py/${LIB_NAME}${DEST_EXT}"
         echo "Copying $SRC_LIB to $DEST_LIB" >&2
         if [ -f "$SRC_LIB" ]; then
             cp "$SRC_LIB" "$DEST_LIB"


### PR DESCRIPTION
## Summary
- fix path to python extension crates when building wheels

## Testing
- `bash scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68420e20af308333bef6ec92f18d4d2f